### PR TITLE
Governing law for legal systems not based on states

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -118,7 +118,7 @@
 
         \Taxes\  Both <Sponsor> and <Developer> agree to do their respective parts for tax compliance concerning fees and expenses paid to <Developer> as an independent contractor under this agreement.
 
-        \Governing Law\  The law of the state where <Developer> lives will govern this agreement
+        \Governing Law\  If the <Developer> lives in a country where states or parts of a country have their own laws, the law of the state or part of the country where <Developer> lives will govern this agreement. If not, the law of the country where <Developer> lives will govern this agreement.
 
         \Whole Agreement\  Both sides intend the <Offer> and these terms as the final, complete, and only expression of their terms about work on the <Issue>.
 


### PR DESCRIPTION
I propose a tweak to the current governing law clause, to extend the applicability of this template to countries which use a non-state based approach to laws (eg principalities or former kingdoms) with a fallback to the country in which the developer lives if there is no concept of state-based law at all.

(However, what if the developer lives across multiple countries or states...)